### PR TITLE
PyHIP Coverage for Kernel Tuner

### DIFF
--- a/pyhip/hip.py
+++ b/pyhip/hip.py
@@ -731,13 +731,19 @@ def hipEventQuery(event):
     """
     Query event status.
 
-    If all work associated with the event has completed, or  hipEventRecord() was not called on the event,
-    this function returns True. If the work has not completed, this function returns False. 
+    If all work associated with the event has completed, or hipEventRecord() 
+    was not called on the event, this function returns True. If the work has 
+    not completed, this function returns False. 
 
     Parameters
     ----------
     event : ctypes pointer
         Event to Query.
+    
+    Returns
+    -------
+    ptr : bool
+        Outcome of Query.
     """
     status = _libhip.hipEventQuery(event)
     if status == 0:       # hipSuccess
@@ -1454,11 +1460,11 @@ _libhip.hipModuleGetGlobal.argtypes = [ctypes.POINTER(ctypes.c_void_p), # symbol
 
 def hipModuleGetGlobal(module, name):
     """
-    Retrieve the pointer to a global variable defined in a HIP module.
+    Retrieve a device memory pointer defined in a HIP module.
 
-    This function retrieves the pointer to a global variable with the specified name 
+    This function retrieves the device memory pointer with the specified name 
     defined in the HIP module specified by `module`. If successful, the function returns 
-    a tuple containing a ctypes pointer to the global variable and its size.
+    a tuple containing a ctypes pointer to the device memory and its size.
 
     Parameters
     ----------
@@ -1466,6 +1472,11 @@ def hipModuleGetGlobal(module, name):
         Handle to the module to retrieve the global variable from.
     name : str
         Name of the global variable to retrieve.
+
+    Returns
+    -------
+    Tuple: (ctypes pointer, ctypes size_t)
+        device memory pointer and its size.
     """
 
     symbol_string = ctypes.c_char_p(name.encode('utf-8'))

--- a/pyhip/hip.py
+++ b/pyhip/hip.py
@@ -107,9 +107,6 @@ class hipError(Exception):
     """hip error"""
     pass
 
-class hipSuccess(hipError):
-    __doc__ = _libhip.hipGetErrorString(0)
-    pass
 
 class hipErrorInvalidValue(hipError):
     __doc__ = _libhip.hipGetErrorString(1)
@@ -407,7 +404,6 @@ class hipErrorRuntimeOther(hipError):
 
 
 hipExceptions = {
-    0: hipSuccess,
     1: hipErrorInvalidValue,
     2: hipErrorOutOfMemory,
     3: hipErrorNotInitialized,
@@ -744,9 +740,9 @@ def hipEventQuery(event):
         Event to Query.
     """
     status = _libhip.hipEventQuery(event)
-    if status == hipSuccess:
+    if status == 0:       # hipSuccess
         return True
-    elif status == hipErrorNotReady:
+    elif status == 600:   # hipErrorNotReady
         return False
     else:
         hipCheckStatus(status)

--- a/pyhip/hip.py
+++ b/pyhip/hip.py
@@ -847,6 +847,29 @@ def hipMallocPitch(pitch, rows, cols, elesize):
     hipCheckStatus(status)
     return ptr, pitch
 
+_libhip.hipMemset.restype = ctypes.c_int
+_libhip.hipMemset.argtypes = [ctypes.c_void_p,  # ptr to allocation
+                              ctypes.c_int,     # value
+                              ctypes.c_size_t]  # bytes to set
+
+def hipMemset(dst, value, sizeBytes):
+    """
+    Fills the first sizeBytes bytes of the memory area pointed to by dst with 
+    the constant byte value value.
+
+    Parameters
+    ----------
+    dst : ctypes pointer
+        Pointer to the memory to set.
+    value : a single 8-bit int
+        The value to set.
+    sizeBytes : int
+        The number of bytes to set.
+    """
+    ctypes_value = ctypes.c_int(value)
+    ctypes_size = ctypes.c_size_t(sizeBytes)
+    status = _libhip.hipMemset(dst, ctypes_value, ctypes_size)
+    hipCheckStatus(status)
 
 # Memory copy modes:
 hipMemcpyHostToHost = 0

--- a/pyhip/hip.py
+++ b/pyhip/hip.py
@@ -107,6 +107,9 @@ class hipError(Exception):
     """hip error"""
     pass
 
+class hipSuccess(hipError):
+    __doc__ = _libhip.hipGetErrorString(0)
+    pass
 
 class hipErrorInvalidValue(hipError):
     __doc__ = _libhip.hipGetErrorString(1)
@@ -404,6 +407,7 @@ class hipErrorRuntimeOther(hipError):
 
 
 hipExceptions = {
+    0: hipSuccess,
     1: hipErrorInvalidValue,
     2: hipErrorOutOfMemory,
     3: hipErrorNotInitialized,
@@ -723,6 +727,29 @@ def hipEventElapsedTime(start, stop):
     status = _libhip.hipEventElapsedTime(ctypes.byref(t), start, stop)
     hipCheckStatus(status)
     return t.value
+
+_libhip.hipEventQuery.restype = ctypes.c_int
+_libhip.hipEventQuery.argtypes = [ctypes.c_void_p]
+
+def hipEventQuery(event):
+    """
+    Query event status.
+
+    If all work associated with the event has completed, or  hipEventRecord() was not called on the event,
+    this function returns True. If the work has not completed, this function returns False. 
+
+    Parameters
+    ----------
+    event : ctypes pointer
+        Event to Query.
+    """
+    status = _libhip.hipEventQuery(event)
+    if status == hipSuccess:
+        return True
+    elif status == hipErrorNotReady:
+        return False
+    else:
+        hipCheckStatus(status)
 
 
 # Memory allocation functions (adapted from pystream):

--- a/pyhip/hip.py
+++ b/pyhip/hip.py
@@ -743,7 +743,7 @@ def hipEventQuery(event):
     Returns
     -------
     ptr : bool
-        Outcome of Query.
+        Outcome of Query, True if event is complete, False otherwise.
     """
     status = _libhip.hipEventQuery(event)
     if status == 0:       # hipSuccess
@@ -1489,7 +1489,7 @@ def hipModuleGetGlobal(module, name):
     status = _libhip.hipModuleGetGlobal(symbol_ptr, size_kernel_ptr, module, symbol_string)
     hipCheckStatus(status)
 
-    return (symbol_ptr.contents, size_kernel_ptr.contents)
+    return (symbol_ptr.contents, size_kernel_ptr.contents.value)
 
 _libhip.hipModuleUnload.restype = int
 _libhip.hipModuleUnload.argtypes = [ctypes.c_void_p]

--- a/pyhip/hip.py
+++ b/pyhip/hip.py
@@ -1427,6 +1427,39 @@ def hipModuleGetFunction(module, func_name):
     hipCheckStatus(status)
     return kernel
 
+_libhip.hipModuleGetGlobal.restype = ctypes.c_int
+_libhip.hipModuleGetGlobal.argtypes = [ctypes.POINTER(ctypes.c_void_p), # symbol ptr
+                                       ctypes.POINTER(ctypes.c_size_t), # size ptr
+                                       ctypes.c_void_p,                 # module
+                                       ctypes.c_char_p]                 # symbol string
+
+def hipModuleGetGlobal(module, name):
+    """
+    Retrieve the pointer to a global variable defined in a HIP module.
+
+    This function retrieves the pointer to a global variable with the specified name 
+    defined in the HIP module specified by `module`. If successful, the function returns 
+    a tuple containing a ctypes pointer to the global variable and its size.
+
+    Parameters
+    ----------
+    module : ctypes pointer
+        Handle to the module to retrieve the global variable from.
+    name : str
+        Name of the global variable to retrieve.
+    """
+
+    symbol_string = ctypes.c_char_p(name.encode('utf-8'))
+    symbol = ctypes.c_void_p()
+    symbol_ptr = ctypes.POINTER(ctypes.c_void_p)(symbol)
+
+    size_kernel = ctypes.c_size_t(0)
+    size_kernel_ptr = ctypes.POINTER(ctypes.c_size_t)(size_kernel)
+
+    status = _libhip.hipModuleGetGlobal(symbol_ptr, size_kernel_ptr, module, symbol_string)
+    hipCheckStatus(status)
+
+    return (symbol_ptr.contents, size_kernel_ptr.contents)
 
 _libhip.hipModuleUnload.restype = int
 _libhip.hipModuleUnload.argtypes = [ctypes.c_void_p]

--- a/tests/event.py
+++ b/tests/event.py
@@ -35,7 +35,9 @@ def test_hipEvents():
     hip.hipMemcpyAsync_htod(ptr, in_val, size, stream)
     hip.hipMemcpyAsync_dtoh(res, ptr, size, stream)
     hip.hipEventRecord(end, stream)
+    assert hip.hipEventQuery(end) == False
     hip.hipEventSynchronize(end)
+    assert hip.hipEventQuery(end) == True
     time = hip.hipEventElapsedTime(start, end)
     assert time > 0
     for i in repeat(0, count):

--- a/tests/memory.py
+++ b/tests/memory.py
@@ -52,3 +52,11 @@ def test_hipMemcpyAsync():
         assert res[i] == in_val[i]
     hip.hipFree(ptr)
     hip.hipStreamDestroy(stream)
+
+def test_memset():
+    size = 4
+    x_d = hip.hipMalloc(size)
+    hip.hipMemset(x_d, 4, size)
+    output = (ctypes.c_int8 * size)()
+    hip.hipMemcpy_dtoh(output, x_d, size)
+    assert all(output[i] == 4 for i in range(len(output)))


### PR DESCRIPTION
Hello,

This pull request adds support for hipEventQuery, hipModuleGetGlobal, and hipMemset to PyHIP. These functions are necessary for achieving full PyHIP coverage for [Kernel Tuner's](https://github.com/KernelTuner/kernel_tuner/pull/199) new HIP backend that is being developed with PyHIP. The implementation includes the following changes:

* Added hipEventQuery, hipModuleGetGlobal, and hipMemset to the PyHIP API.
* Added corresponding tests for hipEventQuery and hipModuleGetGlobal to the tests directory to ensure that the new functions work as expected.
* Tested the implementation with the HIP backend of Kernel Tuner running on AMD, and verified that it works as expected.

Please let me know if you have any questions or concerns about these changes.