### PR TITLE
Increased version to 0.1.2 for PyPI update

### DIFF
--- a/pyhip/__init__.py
+++ b/pyhip/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from . import hip
 from . import hiprtc
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
I have increased the version of PyHIP to 0.1.2 for the new release on PyPI.